### PR TITLE
Lab creation page setup + API calls

### DIFF
--- a/securioty-webapp/package.json
+++ b/securioty-webapp/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "proxy": "http://127.0.0.1:5000",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/securioty-webapp/src/App.tsx
+++ b/securioty-webapp/src/App.tsx
@@ -5,6 +5,7 @@ import Home from "./pages/Home";
 import Lab from "./pages/Lab";
 import Profile from "./pages/Profile";
 import "./App.css";
+import LabCreator from "./pages/LabCreator";
 
 function App() {
   const [loggedIn, setLoggedIn] = useState<boolean>(() => {
@@ -32,6 +33,7 @@ function App() {
           <Route path="/home" element={<Home />} />
           <Route path="/lab" element={<Lab />} />
           <Route path="/profile" element={<Profile />} />
+          <Route path="/LabCreator" element={<LabCreator />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/securioty-webapp/src/App.tsx
+++ b/securioty-webapp/src/App.tsx
@@ -31,9 +31,9 @@ function App() {
         <Routes>
           <Route index element={<Home />} />
           <Route path="/home" element={<Home />} />
-          <Route path="/lab" element={<Lab />} />
+          <Route path="/takinglab" element={<Lab />} />
           <Route path="/profile" element={<Profile />} />
-          <Route path="/LabCreator" element={<LabCreator />} />
+          <Route path="/creatinglab" element={<LabCreator />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/securioty-webapp/src/components/AccountLoginForm.tsx
+++ b/securioty-webapp/src/components/AccountLoginForm.tsx
@@ -23,6 +23,8 @@ const AccountLoginForm = ({
 }: Props) => {
   const [registrationStatus, setRegistrationStatus] = useState<boolean>(false);
 
+  //Triggered when submit button is pressed within login form
+  //Calls the register endpoint if registrationStatus is True, otherwise calls Login endpoint
   function onClickSubmit() {
     if (registrationStatus) {
       axios
@@ -56,6 +58,10 @@ const AccountLoginForm = ({
           if (response.status === 200) {
             onLoginChange(true);
             setLoginMessagePrompt("Successful login!");
+            localStorage.setItem(
+              "ACCOUNT",
+              JSON.stringify({ ...account, token: response.data })
+            );
           }
         })
         .catch(function (error) {
@@ -74,10 +80,10 @@ const AccountLoginForm = ({
     setRegistrationStatus(!registrationStatus);
   }
 
+  //Handling state change
   const handleUserChange = (event: any) => {
     setAccountCredentials({ ...account, username: event.target.value });
   };
-
   const handlePassChange = (event: any) => {
     setAccountCredentials({ ...account, password: event.target.value });
   };
@@ -90,6 +96,7 @@ const AccountLoginForm = ({
   const handleRoleChange = (event: any) => {
     setAccountCredentials({ ...account, role: event.target.value });
   };
+  //End state change handling --------------------------------
 
   return (
     <>

--- a/securioty-webapp/src/components/AccountLoginForm.tsx
+++ b/securioty-webapp/src/components/AccountLoginForm.tsx
@@ -28,7 +28,7 @@ const AccountLoginForm = ({
   function onClickSubmit() {
     if (registrationStatus) {
       axios
-        .post("http://127.0.0.1:5000/auth/register", {
+        .post("/auth/register", {
           email: account.username,
           password: account.password,
           first: account.firstname,
@@ -49,7 +49,7 @@ const AccountLoginForm = ({
         });
     } else {
       axios
-        .post("http://127.0.0.1:5000/auth/login", {
+        .post("/auth/login", {
           email: account.username,
           password: account.password,
         })
@@ -73,7 +73,6 @@ const AccountLoginForm = ({
 
   function onClickLogout() {
     setLoginMessagePrompt("");
-    onClickLogoutSet();
   }
 
   function onClickRegistration() {

--- a/securioty-webapp/src/components/ActiveLab.tsx
+++ b/securioty-webapp/src/components/ActiveLab.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from "react";
-import AnswerBox from "./AnswerBox";
+import { useEffect, useState } from "react";
 import QuestionBox from "./QuestionBox";
 import axios from "axios";
-import accountData from "../scripts/accountData";
+
 //import ProgressBar from 'react-bootstrap/ProgressBar';
 
 interface LabItem {
@@ -23,24 +22,17 @@ const ActiveLab = ({ labItem }: Props) => {
     getProgress();
   }, []);
 
-  const [account, setAccount] = useState<accountData>(() => {
-    const localValue = localStorage.getItem("ACCOUNT");
-    if (localValue == null) {
-      return [];
-    } else {
-      return JSON.parse(localValue);
-    }
-  });
   //ActiveLab.tsx , runs on first render of lab page
   function getProgress() {
-    return axios
-      .post("http://127.0.0.1:5000/Get_Progress", {
-        LabID: labItem.id,
-        UserID: account
-      })
+    const accountData = localStorage.getItem("ACCOUNT");
+    const account = accountData !== null ? JSON.parse(accountData) : "";
+    const h = { Authorization: `Bearer ${account.token.access_token}` };
+    axios
+      .get("/labs/get_progress_percentage/" + labItem.id, { headers: h })
       .then(function (response) {
-        const progressValue = response.data;
+        const progressValue = response.data.progress_percentage;
         setProgress(progressValue);
+        console.log(response.data.progress_percentage);
       })
       .catch(function (error) {
         console.error("Error fetching progress:", error);
@@ -49,23 +41,37 @@ const ActiveLab = ({ labItem }: Props) => {
 
   return (
     <>
-      <body>
-        <h2>{labItem.title}</h2>
-      </body>
+      <h2 className="btn-primary">{labItem.title}</h2>
+
       <div
         className="d-inline-block accordion w-50 px-2 py-2"
         id="accordionExample"
       >
-        <div className="progress-container" style={{ width: '100%' }}>
-            <div className="progress" role="progressbar" aria-label="Example with label" aria-valuenow={progress} aria-valuemin={0} aria-valuemax={100}>
-              <div className="progress-bar custom-progress" style={{ width: `${progress}%` }}>{progress}%</div>
+        <div className="progress-container" style={{ width: "100%" }}>
+          <div
+            className="progress"
+            role="progressbar"
+            aria-label="Example with label"
+            aria-valuenow={progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div
+              className="progress-bar custom-progress"
+              style={{ width: `${progress}%` }}
+            >
+              {progress}%
             </div>
+          </div>
         </div>
-        {labItem.questions.map(question => (
-          <QuestionBox labID={labItem.id} question={question} setProgress={setProgress} />
+        {labItem.questions.map((question) => (
+          <QuestionBox
+            labID={labItem.id}
+            question={question}
+            setProgress={setProgress}
+          />
         ))}
       </div>
-
     </>
   );
 };

--- a/securioty-webapp/src/components/AnswerBox.tsx
+++ b/securioty-webapp/src/components/AnswerBox.tsx
@@ -3,14 +3,14 @@ import React, { FormEvent, useState } from "react";
 import accountData from "../scripts/accountData";
 
 interface Props {
-  labID: number
-  questionID: number
-  setProgress: React.Dispatch<React.SetStateAction<number>>
+  labID: number;
+  questionID: number;
+  setProgress: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const AnswerBox = ({ labID, questionID, setProgress }: Props) => {
-  const [answer, setAnswer] = useState("")
-  const [answerFeedback, setAnswerFeedback] = useState("")
+  const [answer, setAnswer] = useState("");
+  const [answerFeedback, setAnswerFeedback] = useState("");
 
   const [account, setAccount] = useState<accountData>(() => {
     const localValue = localStorage.getItem("ACCOUNT");
@@ -24,17 +24,24 @@ const AnswerBox = ({ labID, questionID, setProgress }: Props) => {
   function handleAnswer(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
-
     //AnswerBox.tsx, runs when user hits "Submit" button in lab
+    const accountData = localStorage.getItem("ACCOUNT");
+    const account = accountData !== null ? JSON.parse(accountData) : "";
+    //console.log(account);
+    const h = { Authorization: `Bearer ${account.token.access_token}` };
     axios
-      .post("http://127.0.0.1:5000/Check_Answer", {
-        answer: answer,
-        LabID: labID,
-        QuestionID: questionID,
-        UserID: account
-      })
+      .post(
+        "http://127.0.0.1:5000/update_progress",
+        {
+          lab_id: labID,
+          question_id: questionID,
+          answer: answer,
+        },
+        { headers: h }
+      )
       .then(function (response) {
         const responseData = response.data;
+        console.log(responseData);
         const success = responseData[0];
         const progress = responseData[1];
 
@@ -44,11 +51,11 @@ const AnswerBox = ({ labID, questionID, setProgress }: Props) => {
         } else {
           setAnswerFeedback("Incorrect. Try again.");
         }
-
       })
-
+      .catch(function (error) {
+        console.log(error);
+      });
   }
-
 
   return (
     <form onSubmit={handleAnswer}>
@@ -56,17 +63,15 @@ const AnswerBox = ({ labID, questionID, setProgress }: Props) => {
         <label className="form-label">Answer</label>
         <input
           value={answer}
-          onChange={e => setAnswer(e.target.value)}
+          onChange={(e) => setAnswer(e.target.value)}
           type="text"
           className="form-control"
-          id="answer1"
           name="answer"
         />
         {answerFeedback !== null && <div>{answerFeedback}</div>}
       </div>
       <button type="submit" className="bg-primary btn btn-primary">
         Submit
-
       </button>
     </form>
   );

--- a/securioty-webapp/src/components/LabCard.tsx
+++ b/securioty-webapp/src/components/LabCard.tsx
@@ -2,24 +2,14 @@ import React, { ReactNode, useState } from "react";
 import AccountPopup from "./AccountLoginForm";
 import LoginButton from "./LoginButton";
 import accountData from "../scripts/accountData";
-
-interface LabItem {
-  id: number;
-  title: string;
-  description: string;
-  questions: { id: number; title: string; description: string }[];
-}
+import lab from "../scripts/lab";
 
 interface Props {
   children: ReactNode;
-  labItem: LabItem;
+  labItem: lab;
 }
 
-
-
-
 const LabCard = ({ children, labItem }: Props) => {
-
   //Commented out code so I can code without backend setup
 
   /*
@@ -39,11 +29,11 @@ const LabCard = ({ children, labItem }: Props) => {
       return JSON.parse(localValue);
     }
   });
-  
-  const handleLabClick = () => {
 
-      localStorage.setItem('currentLab', JSON.stringify(labItem));
-      window.location.href = '/lab';
+  const handleLabClick = () => {
+    localStorage.setItem("currentLab", JSON.stringify(labItem));
+    console.log(labItem);
+    window.location.href = "/lab";
   };
 
   return (
@@ -58,18 +48,18 @@ const LabCard = ({ children, labItem }: Props) => {
             </button>
           ) : (
             <button
-                  type="button"
-                  className="btn btn-primary"
-                  data-bs-toggle="modal"
-                  data-bs-target="#exampleModal"
-                >
-                  Login to Start Learning!
-                </button>
+              type="button"
+              className="btn btn-primary"
+              data-bs-toggle="modal"
+              data-bs-target="#exampleModal"
+            >
+              Login to Start Learning!
+            </button>
           )}
         </div>
       </div>
     </>
   );
-}
+};
 
 export default LabCard;

--- a/securioty-webapp/src/components/LabCard.tsx
+++ b/securioty-webapp/src/components/LabCard.tsx
@@ -1,6 +1,5 @@
-import React, { ReactNode, useState } from "react";
-import AccountPopup from "./AccountLoginForm";
-import LoginButton from "./LoginButton";
+import { ReactNode, useState } from "react";
+
 import accountData from "../scripts/accountData";
 import lab from "../scripts/lab";
 
@@ -10,17 +9,6 @@ interface Props {
 }
 
 const LabCard = ({ children, labItem }: Props) => {
-  //Commented out code so I can code without backend setup
-
-  /*
-  const [account, setAccount] = useState<accountData>({
-    username: '',
-    password: '',
-    firstname: '',
-    lastname: '',
-    role: ''
-  });
-  */
   const [account, setAccount] = useState<accountData>(() => {
     const localValue = localStorage.getItem("ACCOUNT");
     if (localValue == null) {
@@ -33,7 +21,7 @@ const LabCard = ({ children, labItem }: Props) => {
   const handleLabClick = () => {
     localStorage.setItem("currentLab", JSON.stringify(labItem));
     console.log(labItem);
-    window.location.href = "/lab";
+    window.location.href = "/takinglab";
   };
 
   return (
@@ -42,7 +30,7 @@ const LabCard = ({ children, labItem }: Props) => {
         <div className="card-body">
           <h5 className="card-title">{labItem.title}</h5>
           <p className="card-text">{children}</p>
-          {Object.keys(account).length > 0 ? (
+          {account.token != "" ? (
             <button onClick={handleLabClick} className="btn btn-primary">
               Start Learning!
             </button>

--- a/securioty-webapp/src/components/LabCreationForm.tsx
+++ b/securioty-webapp/src/components/LabCreationForm.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from "react";
+import lab from "../scripts/lab";
+import axios from "axios";
+
+const LabCreationForm = () => {
+  const [newLab, setNewLab] = useState<lab>({
+    id: 99,
+    title: "",
+    description: "",
+    questions: [{ id: 1, title: "", description: "", answer: "" }],
+  });
+  const [questionCount, setQuestionCount] = useState<number>(2);
+
+  //Triggered when the "Add Question" button is clicked
+  //Dynamically adds a new question field
+  const addQuestion = () => {
+    setQuestionCount(questionCount + 1);
+    console.log(questionCount);
+    const newQuestions = [
+      ...newLab.questions,
+      { id: questionCount, title: "", description: "", answer: "" },
+    ];
+    setNewLab({ ...newLab, questions: newQuestions });
+    console.log(newLab);
+  };
+
+  //Triggered when the "Remove Question" button is clicked
+  //Dynamically removes a question field
+  const removeQuestion = () => {
+    if (questionCount > 1) {
+      setQuestionCount(questionCount - 1);
+    } else {
+      return;
+    }
+    console.log(questionCount);
+    const newQuestions = [...newLab.questions];
+    newQuestions.pop();
+    console.log(newQuestions);
+
+    setNewLab({ ...newLab, questions: newQuestions });
+    console.log(newLab);
+  };
+
+  //Field updating so state is stored properly
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewLab({ ...newLab, title: e.target.value });
+    console.log(newLab);
+  };
+  const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNewLab({ ...newLab, description: e.target.value });
+    console.log(newLab);
+  };
+  const handleQuestionChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    id: number,
+    field: string
+  ) => {
+    const newQuestions = newLab.questions.map((question) => {
+      if (question.id === id) {
+        // we know we need to update this question
+        const updatedQuestion = { ...question, [field]: e.target.value };
+        return updatedQuestion;
+      } else {
+        return question;
+      }
+    });
+    setNewLab({ ...newLab, questions: newQuestions });
+    console.log(newLab);
+  };
+  // End field updating -----------------------------------------------------
+
+  //Triggered when submit is pressed
+  //Calls API endpoint to create new lab with current data fields
+  const submitLab = () => {
+    const accountData = localStorage.getItem("ACCOUNT");
+    const account = accountData !== null ? JSON.parse(accountData) : "";
+    console.log(account.token.access_token);
+    const h = { Authorization: `Bearer ${account.token.access_token}` };
+    axios
+      .post("http://127.0.0.1:5000/labs/create_lab", newLab, { headers: h })
+      .then(function (response) {
+        console.log(response);
+        if (response.status === 201) {
+          alert("Successfully created!");
+          setNewLab({
+            id: 99,
+            title: "",
+            description: "",
+            questions: [{ id: 1, title: "", description: "", answer: "" }],
+          });
+        }
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  };
+
+  return (
+    <>
+      <div className="container bg-secondary ">
+        <div className="mb-3">
+          <label className="form-label">Lab Title</label>
+          <input
+            type="text"
+            className="form-control"
+            value={newLab.title}
+            placeholder="Title"
+            onChange={handleTitleChange}
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Lab Description</label>
+          <input
+            type="text"
+            className="form-control"
+            value={newLab.description}
+            placeholder="Description"
+            onChange={handleDescriptionChange}
+          />
+        </div>
+        {newLab.questions.map((question) => (
+          <div className="mb-3">
+            <label className="form-label">Question {question.id}</label>
+            <input
+              type="text"
+              className="form-control"
+              value={question.title}
+              key={question.id}
+              placeholder="Title"
+              onChange={(e) => handleQuestionChange(e, question.id, "title")}
+            />
+            <input
+              type="text"
+              className="form-control"
+              value={question.description}
+              key={question.id}
+              placeholder="Description"
+              onChange={(e) =>
+                handleQuestionChange(e, question.id, "description")
+              }
+            />
+
+            <input
+              type="text"
+              className="form-control"
+              value={question.answer}
+              placeholder="Answer"
+              onChange={(e) => handleQuestionChange(e, question.id, "answer")}
+            />
+          </div>
+        ))}
+        <button className="btn btn-primary m-2" onClick={addQuestion}>
+          Add Question
+        </button>
+        <button className="btn btn-primary m-2" onClick={removeQuestion}>
+          Remove Question
+        </button>
+        <button
+          className="btn btn-primary m-2 justify-content-end"
+          onClick={submitLab}
+        >
+          Submit
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default LabCreationForm;

--- a/securioty-webapp/src/components/LabCreationForm.tsx
+++ b/securioty-webapp/src/components/LabCreationForm.tsx
@@ -15,13 +15,11 @@ const LabCreationForm = () => {
   //Dynamically adds a new question field
   const addQuestion = () => {
     setQuestionCount(questionCount + 1);
-    console.log(questionCount);
     const newQuestions = [
       ...newLab.questions,
       { id: questionCount, title: "", description: "", answer: "" },
     ];
     setNewLab({ ...newLab, questions: newQuestions });
-    console.log(newLab);
   };
 
   //Triggered when the "Remove Question" button is clicked
@@ -32,23 +30,18 @@ const LabCreationForm = () => {
     } else {
       return;
     }
-    console.log(questionCount);
     const newQuestions = [...newLab.questions];
     newQuestions.pop();
-    console.log(newQuestions);
 
     setNewLab({ ...newLab, questions: newQuestions });
-    console.log(newLab);
   };
 
   //Field updating so state is stored properly
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNewLab({ ...newLab, title: e.target.value });
-    console.log(newLab);
   };
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setNewLab({ ...newLab, description: e.target.value });
-    console.log(newLab);
   };
   const handleQuestionChange = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -65,7 +58,6 @@ const LabCreationForm = () => {
       }
     });
     setNewLab({ ...newLab, questions: newQuestions });
-    console.log(newLab);
   };
   // End field updating -----------------------------------------------------
 
@@ -74,12 +66,10 @@ const LabCreationForm = () => {
   const submitLab = () => {
     const accountData = localStorage.getItem("ACCOUNT");
     const account = accountData !== null ? JSON.parse(accountData) : "";
-    console.log(account.token.access_token);
     const h = { Authorization: `Bearer ${account.token.access_token}` };
     axios
-      .post("http://127.0.0.1:5000/labs/create_lab", newLab, { headers: h })
+      .post("/labs/create_lab", newLab, { headers: h })
       .then(function (response) {
-        console.log(response);
         if (response.status === 201) {
           alert("Successfully created!");
           setNewLab({

--- a/securioty-webapp/src/components/LabSet.tsx
+++ b/securioty-webapp/src/components/LabSet.tsx
@@ -64,7 +64,7 @@ const LabSet = () => {
   //API call to get all labs within the db
   function showLabs() {
     axios
-      .get("http://127.0.0.1:5000/labs/get_labs", {})
+      .get("/labs/get_labs", {})
       .then(function (response) {
         if (response.status === 200) {
           console.log(response.data);

--- a/securioty-webapp/src/components/LabSet.tsx
+++ b/securioty-webapp/src/components/LabSet.tsx
@@ -1,50 +1,95 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Card from "./LabCard";
+import axios from "axios";
+import Lab from "../pages/Lab";
+import lab from "../scripts/lab";
 
 const LabSet = () => {
+  //Hook that calls the showLabs method on component load
+  const [labArray, setLabArray] = useState<lab[]>();
+  useEffect(() => {
+    showLabs();
+  }, []);
 
+  // Dummy data set for testing
+  /*
   const Labs = [
     {
       id: 1,
-      title: 'Lab 1',
-      description: 'Description for Lab 1',
+      title: "Lab 1",
+      description: "Description for Lab 1",
       questions: [
-        { id: 1, title: 'Question 1', description: 'Description for Lab 1 Question 1' },
-        { id: 2, title: 'Question 2', description: 'Description for Lab 1 Question 2' },
-        { id: 3, title: 'Question 3', description: 'Description for Lab 1 Question 3' },
-
-      ]
+        {
+          id: 1,
+          title: "Question 1",
+          description: "Description for Lab 1 Question 1",
+          answer: "dogs",
+        },
+        {
+          id: 2,
+          title: "Question 2",
+          description: "Description for Lab 1 Question 2",
+          answer: "dogs",
+        },
+        {
+          id: 3,
+          title: "Question 3",
+          description: "Description for Lab 1 Question 3",
+          answer: "dogs",
+        },
+      ],
     },
     {
       id: 2,
-      title: 'Lab 2',
-      description: 'Description for Lab 2',
+      title: "Lab 2",
+      description: "Description for Lab 2",
       questions: [
-        { id: 1, title: 'Question 1', description: 'Description for Lab 2 Question 1' },
-        { id: 2, title: 'Question 2', description: 'Description for Lab 2 Question 2' },
-      ]
+        {
+          id: 1,
+          title: "Question 1",
+          description: "Description for Lab 2 Question 1",
+          answer: "dogs",
+        },
+        {
+          id: 2,
+          title: "Question 2",
+          description: "Description for Lab 2 Question 2",
+          answer: "dogs",
+        },
+      ],
     },
   ];
+  */
 
-
-  const [labArray, setLabArray] = useState(Labs)
-
+  //API call to get all labs within the db
+  function showLabs() {
+    axios
+      .get("http://127.0.0.1:5000/labs/get_labs", {})
+      .then(function (response) {
+        if (response.status === 200) {
+          console.log(response.data);
+          const calledLabs = response.data;
+          setLabArray(calledLabs);
+          console.log(labArray);
+        }
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  }
 
   return (
     <>
       <div className="container text-center overflow-hidden px-4">
         <div className="row row-cols-3 gx-5 pt-5">
-
-          {labArray.map(lab => {
-            return (
-              <div className="p-4" key={lab.id}>
-                <Card labItem={lab}>
-                  {lab.description}
-                </Card>
-              </div>
-            )
-          })}
-
+          {labArray !== undefined &&
+            labArray.map((lab) => {
+              return (
+                <div className="p-4" key={lab.id}>
+                  <Card labItem={lab}>{lab.description}</Card>
+                </div>
+              );
+            })}
         </div>
       </div>
     </>

--- a/securioty-webapp/src/components/NavBar.tsx
+++ b/securioty-webapp/src/components/NavBar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import AccountPopup from "./AccountLoginForm";
 import LoginButton from "./LoginButton";
 import accountData from "../scripts/accountData";
+import AccountLoginForm from "./AccountLoginForm";
 
 interface Props {
   onLoginChange: (arg0: boolean) => void;
@@ -37,7 +37,15 @@ const NavBar = ({ onLoginChange, loggedIn }: Props) => {
 
   function onClickLogout() {
     setLoggedInState(false);
-    setAccountCredentials({ ...account, username: "", password: "" });
+    var emptyAccount: accountData = {
+      username: "",
+      password: "",
+      firstname: "",
+      lastname: "",
+      role: "",
+      token: "",
+    };
+    setAccount(emptyAccount);
     setLoginMessage("");
   }
 
@@ -75,15 +83,17 @@ const NavBar = ({ onLoginChange, loggedIn }: Props) => {
                   </a>
                 </li>
               )}
-              <a
-                className="nav-link active"
-                aria-current="page"
-                href="/LabCreator"
-              >
-                Create Lab
-              </a>
+              {loggedIn && (
+                <a
+                  className="nav-link active"
+                  aria-current="page"
+                  href="/creatinglab"
+                >
+                  Create Lab
+                </a>
+              )}
               <LoginButton loggedIn={loggedIn} />
-              <AccountPopup
+              <AccountLoginForm
                 onClickLogoutSet={onClickLogout}
                 setAccountCredentials={setAccountCredentials}
                 account={account}

--- a/securioty-webapp/src/components/NavBar.tsx
+++ b/securioty-webapp/src/components/NavBar.tsx
@@ -75,6 +75,13 @@ const NavBar = ({ onLoginChange, loggedIn }: Props) => {
                   </a>
                 </li>
               )}
+              <a
+                className="nav-link active"
+                aria-current="page"
+                href="/LabCreator"
+              >
+                Create Lab
+              </a>
               <LoginButton loggedIn={loggedIn} />
               <AccountPopup
                 onClickLogoutSet={onClickLogout}

--- a/securioty-webapp/src/components/VMWindow.tsx
+++ b/securioty-webapp/src/components/VMWindow.tsx
@@ -1,12 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
 
 const VMWindow = () => {
+  const [vmActive, setVmActive] = useState<boolean>(false);
+
+  const activateVM = () => {
+    setVmActive(!vmActive);
+  };
   return (
-    <div className="d-flex  align-items-center w-50 vh-100 container float-end">
-      <button className="btn btn-primary d-block w-25 mx-auto my-">
-        Launch VM
+    <>
+      {vmActive && (
+        <div className="d-flex  align-items-center w-50 vh-130 container float-end">
+          <iframe
+            name="iframe-vm"
+            src="http://192.168.10.4:8081/vnc.html?host=192.168.10.4&port=8081&password=admin123&autoconnect=true"
+            width="800"
+            height="600"
+          ></iframe>
+        </div>
+      )}
+      <button className={"btn btn-primary"} onClick={activateVM}>
+        {vmActive ? "Terminate VM" : "Launch VM"}
       </button>
-    </div>
+    </>
   );
 };
 

--- a/securioty-webapp/src/pages/Lab.tsx
+++ b/securioty-webapp/src/pages/Lab.tsx
@@ -1,14 +1,8 @@
-import React from "react";
 import ActiveLab from "../components/ActiveLab";
 import VMWindow from "../components/VMWindow";
 
-
-
-
-
 const Lab = () => {
-
-  const selectedLab = JSON.parse(localStorage.getItem('currentLab') || 'null');
+  const selectedLab = JSON.parse(localStorage.getItem("currentLab") || "null");
   return (
     <>
       <ActiveLab labItem={selectedLab} />

--- a/securioty-webapp/src/pages/LabCreator.tsx
+++ b/securioty-webapp/src/pages/LabCreator.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import LabCreationForm from "../components/LabCreationForm";
+
+const LabCreator = () => {
+  return (
+    <>
+      <LabCreationForm></LabCreationForm>
+    </>
+  );
+};
+
+export default LabCreator;

--- a/securioty-webapp/src/scripts/accountData.ts
+++ b/securioty-webapp/src/scripts/accountData.ts
@@ -4,6 +4,7 @@ interface account {
     firstname: string;
     lastname: string;
     role: string;
+    token: string;
   }
 
 export default account;

--- a/securioty-webapp/src/scripts/lab.ts
+++ b/securioty-webapp/src/scripts/lab.ts
@@ -1,0 +1,10 @@
+import labQuestion from "./labQuestion";
+
+interface lab {
+    id: number;
+    title: string;
+    description: string;
+    questions: labQuestion[];
+  }
+
+export default lab;

--- a/securioty-webapp/src/scripts/labQuestion.ts
+++ b/securioty-webapp/src/scripts/labQuestion.ts
@@ -1,0 +1,8 @@
+interface labQuestion {
+    id: number;
+    title: string;
+    description: string;
+    answer: string;
+  }
+
+export default labQuestion;

--- a/securioty-webapp/vite.config.ts
+++ b/securioty-webapp/vite.config.ts
@@ -3,5 +3,11 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    proxy: {
+      '/labs': 'http://127.0.0.1:5000',
+      '/auth': 'http://127.0.0.1:5000'
+    }
+  },
   plugins: [react()],
 })


### PR DESCRIPTION
* Refactored AnswerBox API call to give token
* Changed LabCard to use lab data object within scripts
* Wrote fully functioning LabCreationPage that allows for dynamic adding/ removing of question fields, connected to the API via call, but doesnt stick in db for some reason
* Commented out dummy code in LabSet and added API call that retrieves all labs within the db displaying them on homepage
* Added token to accountData.ts so that it can be used on necessary auth calls
* Added lab and labQuestion datatypes for easy reuse in future
* Added route + page for LabCreation
* Added various comments on files for better navigation and understanding